### PR TITLE
only take the portion of above ground bm left

### DIFF
--- a/field_initialisation.R
+++ b/field_initialisation.R
@@ -41,7 +41,7 @@ field_crop_data <- carbon_input_data %>%
          total_bm = yield_bm + above_ground_bm,
          roots_bm = total_bm * root_shoot_ratio,
          extra_roots_bm = roots_bm * rhizodeposition,
-         total_c_input_tc = (above_ground_bm + roots_bm + extra_roots_bm)/1000) %>% 
+         total_c_input_tc = (above_ground_bm*residue + roots_bm + extra_roots_bm)/1000) %>% 
   mutate(across(contains("year"),
                 ~ case_when(is_crop == "manure" ~ annual_quantity,
                             is_crop == "crop" ~ .x * total_c_input_tc)))


### PR DESCRIPTION
The residue factor is an input in the carbon inputs file. This adds it in to the C in estimation by multiplying the above ground bm (anything above ground after harvest) by the % of bm left on the fields. 0 is no bm is left, 1 is all bm is left. 